### PR TITLE
Add hook to forcibly disallow deflecting bullets

### DIFF
--- a/lua/weapons/weapon_lscs/sv_blocking.lua
+++ b/lua/weapons/weapon_lscs/sv_blocking.lua
@@ -16,6 +16,8 @@ function SWEP:CanDeflect()
 		return false
 	end
 
+	if hook.Run("LSCS:PreventDeflect", self) then return false end
+
 	return (self._nextDeflect or 0) < CurTime()
 end
 


### PR DESCRIPTION
HI! Added a small change to call hook before allowing deflecting, so there possibility to control who can deflect and who can't.

Not sure about name tho, maybe it's something that needed to be changed.